### PR TITLE
Lower cmake minimum version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.10)
 project(fcitx5-libthai VERSION 5.0.9)
 find_package(ECM REQUIRED 1.0.0)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})


### PR DESCRIPTION
Upstream one patch from https://build.opensuse.org/package/view_file/M17N/fcitx5-libthai/fcitx5-libthai-cmake-3.10.patch?expand=1